### PR TITLE
Revert "sf: Make sure HWC_BLENDING_NONE is set for opaque layer"

### DIFF
--- a/services/surfaceflinger/Layer.cpp
+++ b/services/surfaceflinger/Layer.cpp
@@ -477,7 +477,7 @@ void Layer::setGeometry(
 
     // this gives us only the "orientation" component of the transform
     const State& s(getDrawingState());
-    if (!isOpaque(s)) {
+    if (!isOpaque(s) || s.alpha != 0xFF) {
         layer.setBlending(mPremultipliedAlpha ?
                 HWC_BLENDING_PREMULT :
                 HWC_BLENDING_COVERAGE);


### PR DESCRIPTION
This reverts commit dda1fa34430841943622dfea055dff98225d7df9.
- Blending issue is observed if HWC_BLENDING_NONE is used for layer
having plane alpha.

Change-Id: I67e5d1059e81d5a7c17b0e330429f09690d32721